### PR TITLE
allow updating sets

### DIFF
--- a/src/clj/com/rpl/specter/impl.clj
+++ b/src/clj/com/rpl/specter/impl.clj
@@ -143,14 +143,7 @@
     (into [] (r/mapcat (partial next-fn vals) structure)))
   (update* [this vals structure next-fn]
     (let [ret (r/map (partial next-fn vals) structure)]
-      (cond (vector? structure)
-            (into [] ret)
-
-            (map? structure)
-            (into {} ret)
-            
-            :else
-            (into '() ret)))
+      (into (empty structure) ret))
     ))
 
 (deftype ValStructurePath []


### PR DESCRIPTION
This update changes the update functionality to work on sets.
Before, 
(update [ALL :a even?] inc #{{:a 1} {:a 2} {:a 4} {:a 3}})

would return this (converting the result to a list):
({:a 3} {:a 5} {:a 3} {:a 1})

Now, it returns this:
=> #{{:a 1} {:a 3} {:a 5}}