### PR TITLE
Avoid warnings about overriding 'update'

### DIFF
--- a/src/clj/com/rpl/specter.clj
+++ b/src/clj/com/rpl/specter.clj
@@ -1,4 +1,5 @@
 (ns com.rpl.specter
+  (:refer-clojure :exclude [update])
   (:use [com.rpl.specter impl protocols])
   )
 

--- a/test/clj/com/rpl/specter/core_test.clj
+++ b/test/clj/com/rpl/specter/core_test.clj
@@ -1,4 +1,5 @@
 (ns com.rpl.specter.core-test
+  (:refer-clojure :exclude [update])
   (:use [clojure.test]
         [clojure.test.check.clojure-test]
         [com.rpl specter]


### PR DESCRIPTION
Clojure 1.7 includes an 'update' function in the standard library;
exclude that from the imports explicitly. This still works in 1.6, where
the update function does not exist.