### PR TITLE
Add new "subselect" path selector

### DIFF
--- a/src/clj/com/rpl/specter.cljx
+++ b/src/clj/com/rpl/specter.cljx
@@ -258,7 +258,11 @@
 
 (defn select-view
   "Navigates to a sequence that contains the results of (select ...),
-  but is a view to the original structure that can be transformed."
+  but is a view to the original structure that can be transformed.
+
+  Requires that the input navigators will walk the structure's
+  children in the same order when executed on \"select\" and then
+  \"transform\"."
   [& path]
   (fixed-pathed-path [late path]
     (select* [this structure next-fn]

--- a/src/clj/com/rpl/specter.cljx
+++ b/src/clj/com/rpl/specter.cljx
@@ -256,7 +256,7 @@
                 ancestry))
       )))
 
-(defn select-view
+(defn subselect
   "Navigates to a sequence that contains the results of (select ...),
   but is a view to the original structure that can be transformed.
 

--- a/src/clj/com/rpl/specter.cljx
+++ b/src/clj/com/rpl/specter.cljx
@@ -266,10 +266,10 @@
     (transform* [this structure next-fn]
       (let [select-result (compiled-select late structure)
             transformed (next-fn select-result)
-            values-to-insert (atom transformed)]
+            values-to-insert (i/mutable-cell transformed)]
         (compiled-transform late
-                            (fn [_] (let [next-val (first @values-to-insert)]
-                                      (swap! values-to-insert rest)
+                            (fn [_] (let [next-val (first (i/get-cell values-to-insert))]
+                                      (i/update-cell! values-to-insert rest)
                                       next-val))
                             structure)))))
 

--- a/src/clj/com/rpl/specter.cljx
+++ b/src/clj/com/rpl/specter.cljx
@@ -256,6 +256,23 @@
                 ancestry))
       )))
 
+(defn select-view
+  "Navigates to a sequence that contains the results of (select ...),
+  but is a view to the original structure that can be transformed."
+  [& path]
+  (fixed-pathed-path [late path]
+    (select* [this structure next-fn]
+             (next-fn (compiled-select late structure)))
+    (transform* [this structure next-fn]
+      (let [select-result (compiled-select late structure)
+            transformed (next-fn select-result)
+            values-to-insert (atom transformed)]
+        (compiled-transform late
+                            (fn [_] (let [next-val (first @values-to-insert)]
+                                      (swap! values-to-insert rest)
+                                      next-val))
+                            structure)))))
+
 (defpath keypath [key]
   (select* [this structure next-fn]
     (next-fn (get structure key)))

--- a/test/com/rpl/specter/core_test.cljx
+++ b/test/com/rpl/specter/core_test.cljx
@@ -510,18 +510,18 @@
            ))
     ))
 
-(defspec select-view-nested-vectors
+(defspec subselect-nested-vectors
   (for-all+
     [v1 (gen/vector
          (gen/vector gen/int))]
-    (let [path (s/comp-paths (s/select-view s/ALL s/ALL))
+    (let [path (s/comp-paths (s/subselect s/ALL s/ALL))
           v2 (s/compiled-transform path reverse v1)]
       (and
         (= (s/compiled-select path v1) [(flatten v1)])
         (= (flatten v1) (reverse (flatten v2)))
         (= (map count v1) (map count v2))))))
 
-(defspec select-view-param-test
+(defspec subselect-param-test
   (for-all+
     [k gen/keyword
      v (gen/vector
@@ -531,9 +531,9 @@
              gen/int
              k)))]
     (and
-     (= (s/compiled-select ((s/select-view s/ALL s/keypath) k) v)
+     (= (s/compiled-select ((s/subselect s/ALL s/keypath) k) v)
         [(map k v)])
-     (let [v2 (s/compiled-transform ((s/comp-paths (s/select-view s/ALL s/keypath)) k)
+     (let [v2 (s/compiled-transform ((s/comp-paths (s/subselect s/ALL s/keypath)) k)
                                     reverse
                                     v)]
        (and (= (map k v) (reverse (map k v2)))

--- a/test/com/rpl/specter/core_test.cljx
+++ b/test/com/rpl/specter/core_test.cljx
@@ -510,6 +510,37 @@
            ))
     ))
 
+(defspec select-view-nested-vectors
+  (for-all+
+    [v1 (gen/vector
+         (gen/vector gen/int))]
+    (let [path (s/comp-paths (s/select-view s/ALL s/ALL))
+          v2 (s/compiled-transform path reverse v1)]
+      (and
+        (= (s/compiled-select path v1) [(flatten v1)])
+        (= (flatten v1) (reverse (flatten v2)))
+        (= (map count v1) (map count v2))))))
+
+(defspec select-view-param-test
+  (for-all+
+    [k gen/keyword
+     v (gen/vector
+         (limit-size 5
+           (gen-map-with-keys
+             gen/keyword
+             gen/int
+             k)))]
+    (and
+     (= (s/compiled-select ((s/select-view s/ALL s/keypath) k) v)
+        [(map k v)])
+     (let [v2 (s/compiled-transform ((s/comp-paths (s/select-view s/ALL s/keypath)) k)
+                                    reverse
+                                    v)]
+       (and (= (map k v) (reverse (map k v2)))
+            (= (map #(dissoc % k) v)
+               (map #(dissoc % k) v2))) ; only key k was touched in any of the maps
+       ))))
+
 (defspec param-multi-path-test
   (for-all+
     [k1 gen/keyword

--- a/test/com/rpl/specter/core_test.cljx
+++ b/test/com/rpl/specter/core_test.cljx
@@ -671,8 +671,8 @@
   (is (= {:a {:aaa 4 :b {:c {:aaa 3} :aaa 2}}}
          (s/transform (map-key-walker :aaa) inc
                       {:a {:aaa 3  :b {:c {:aaa 2} :aaa 1}}})))
-  (is (= {:a {:c {:b "X"}}})
-      (s/setval (map-key-walker :b) "X" {:a {:c {:b {:d 1}}}}))
+  (is (= {:a {:c {:b "X"}}}
+         (s/setval (map-key-walker :b) "X" {:a {:c {:b {:d 1}}}})))
   )
 
 (deftest recursive-params-composable-path-test


### PR DESCRIPTION
This is inspired by the existing "view" path selectors such as `filterer` and `srange`, but is more general-purpose as it can be applied to arbitrary (sub-)paths.

With `select-view` in the specter toolbelt, more complex problems can now be easily solved:
```clojure
;; Reverse all even :a values across several maps.
(transform [(select-view ALL :a even?)]
           reverse 
            [{:a 1} {:a 2} {:a 3} {:a 4}])
 =>
[{:a 1} {:a 4} {:a 3} {:a 2}]

;; Shuffle the values in each map.
(transform [ALL (select-view ALL LAST)]
           shuffle
           [{:a 1 :b 2 :c 3}
            {:d :hello :e 'saluton :f "aloha"}])
=>
 [{:a 3, :b 2, :c 1} {:d saluton, :e "aloha", :f :hello}]

;; Reverse only the even leafs of a tree.
(defprotocolpath AllNestedInts [])
(extend-protocolpath AllNestedInts
  clojure.lang.Seqable [ALL AllNestedInts]
  Long STAY)
(transform [(select-view AllNestedInts) (filterer even?)]
           reverse
           [[[0] 1] [2 3 [4 [5]]]])
 =>
 [[[4] 1] [2 3 [0 [5]]]]
```

EDIT: `select-view` has been changed to `subselect`