### PR TITLE
add a submap path

### DIFF
--- a/src/clj/com/rpl/specter.cljx
+++ b/src/clj/com/rpl/specter.cljx
@@ -218,6 +218,25 @@
           )))
 
 (defpath
+  submap*
+  [m-keys]
+  (select* [this structure next-fn]
+    (next-fn (merge (zipmap m-keys (repeat nil)) (select-keys structure m-keys))))
+
+  (transform* [this structure next-fn]
+    (let [submap (merge (zipmap m-keys (repeat nil)) (select-keys structure m-keys))
+          newmap (next-fn submap)]
+      (merge (apply dissoc structure m-keys)
+             newmap))))
+
+(defn submap
+  "Navigates to the specified submap (by attempting a get for each key).
+   In a transform, that submap in the original map is changed to the new
+   value of the submap."
+  [& m-keys]
+  (submap* m-keys))
+
+(defpath
   walker
   [afn]
   (select* [this structure next-fn]

--- a/src/clj/com/rpl/specter.cljx
+++ b/src/clj/com/rpl/specter.cljx
@@ -218,23 +218,19 @@
           )))
 
 (defpath
-  submap*
+  ^{:doc "Navigates to the specified submap (using select-keys).
+          In a transform, that submap in the original map is changed to the new
+          value of the submap."}
+  submap
   [m-keys]
   (select* [this structure next-fn]
-    (next-fn (merge (zipmap m-keys (repeat nil)) (select-keys structure m-keys))))
+    (next-fn (select-keys structure m-keys)))
 
   (transform* [this structure next-fn]
-    (let [submap (merge (zipmap m-keys (repeat nil)) (select-keys structure m-keys))
+    (let [submap (select-keys structure m-keys)
           newmap (next-fn submap)]
-      (merge (apply dissoc structure m-keys)
+      (merge (reduce dissoc structure m-keys)
              newmap))))
-
-(defn submap
-  "Navigates to the specified submap (by attempting a get for each key).
-   In a transform, that submap in the original map is changed to the new
-   value of the submap."
-  [& m-keys]
-  (submap* m-keys))
 
 (defpath
   walker

--- a/test/com/rpl/specter/core_test.cljx
+++ b/test/com/rpl/specter/core_test.cljx
@@ -574,16 +574,16 @@
         ))))
 
 (deftest submap-test
-  (is (= [{:foo 1, :baz nil}]
-         (s/select [(s/submap :foo :baz)] {:foo 1 :bar 2})))
+  (is (= [{:foo 1}]
+         (s/select [(s/submap [:foo :baz])] {:foo 1 :bar 2})))
   (is (= {:foo 1, :barry 1}
-         (s/setval [(s/submap :bar)] {:barry 1} {:foo 1 :bar 2})))
-  (is (= {:bar 1, :foo 2, :baz nil}
-         (s/transform [(s/submap :foo :baz) s/ALL s/LAST (comp not nil?)] inc {:foo 1 :bar 1})))
+         (s/setval [(s/submap [:bar])] {:barry 1} {:foo 1 :bar 2})))
+  (is (= {:bar 1, :foo 2}
+         (s/transform [(s/submap [:foo :baz]) s/ALL s/LAST] inc {:foo 1 :bar 1})))
   (is (= {:a {:new 1}
           :c {:new 1
               :old 1}}
-         (s/setval [s/ALL s/LAST (s/submap)] {:new 1} {:a nil, :c {:old 1}}))))
+         (s/setval [s/ALL s/LAST (s/submap [])] {:new 1} {:a nil, :c {:old 1}}))))
 
 (deftest nil->val-test
   (is (= {:a #{:b}}

--- a/test/com/rpl/specter/core_test.cljx
+++ b/test/com/rpl/specter/core_test.cljx
@@ -573,6 +573,18 @@
         (= (s/setval (s/subset s3) s4 combined) (-> combined (set/difference s2) (set/union s4)))
         ))))
 
+(deftest submap-test
+  (is (= [{:foo 1, :baz nil}]
+         (s/select [(s/submap :foo :baz)] {:foo 1 :bar 2})))
+  (is (= {:foo 1, :barry 1}
+         (s/setval [(s/submap :bar)] {:barry 1} {:foo 1 :bar 2})))
+  (is (= {:bar 1, :foo 2, :baz nil}
+         (s/transform [(s/submap :foo :baz) s/ALL s/LAST (comp not nil?)] inc {:foo 1 :bar 1})))
+  (is (= {:a {:new 1}
+          :c {:new 1
+              :old 1}}
+         (s/setval [s/ALL s/LAST (s/submap)] {:new 1} {:a nil, :c {:old 1}}))))
+
 (deftest nil->val-test
   (is (= {:a #{:b}}
          (s/setval [:a s/NIL->SET (s/subset #{})] #{:b} nil)))


### PR DESCRIPTION
I'm especially pleased with the last test just working, as I only thought of trying it after watching your talk where you did the same thing with a set.

Having submaps created by simulating repeatedly calling get, rather than behaving like select-keys is maybe questionable, but I figured clojure already has a select-keys function.

/cc @nathanmarz 