### PR TITLE
minor cljs testing doc change

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -8,7 +8,7 @@ lein cleantest
 
 ```
 rm -rf out/
-lein cljx
+lein do javac, cljx
 rlwrap java -cp `lein classpath` clojure.main repl.clj
 (require 'com.rpl.specter.cljs-test-runner)
 ```


### PR DESCRIPTION
When starting with a fresh checkout, someone following the
Clojurescript testing instructions will run into a
ClassNotFoundException: com.rpl.specter.Util.

This patch just adds a "javac" task to the instructions.