### PR TITLE
Transient navigators

### DIFF
--- a/src/clj/com/rpl/specter/impl.cljx
+++ b/src/clj/com/rpl/specter/impl.cljx
@@ -466,6 +466,14 @@
 (defn vec-count [v]
   (count v))
 
+#+clj
+(defn transient-vec-count [^clojure.lang.ITransientVector v]
+  (.count v))
+
+#+cljs
+(defn transient-vec-count [v]
+  (count v))
+
 (extend-protocol UpdateExtremes
   #+clj clojure.lang.PersistentVector #+cljs cljs.core/PersistentVector
   (update-first [v afn]
@@ -505,6 +513,9 @@
   #+clj clojure.lang.IPersistentVector #+cljs cljs.core/PersistentVector
   (fast-empty? [v]
     (= 0 (vec-count v)))
+  #+clj clojure.lang.ITransientVector #+cljs cljs.core/TransientVector
+  (fast-empty? [v]
+    (= 0 (transient-vec-count v)))
   #+clj Object #+cljs default
   (fast-empty? [s]
     (empty? s))
@@ -762,20 +773,10 @@
 (extend-protocol p/Navigator
   TransientEndNavigator
   (select* [this structure next-fn]
-    [])
+    (next-fn []))
   (transform* [this structure next-fn]
     (let [res (next-fn [])]
       (reduce conj! structure res))))
-
-(deftype TransientLastNavigator [])
-
-(extend-protocol p/Navigator
-  TransientLastNavigator
-  (select* [this structure next-fn]
-    (next-fn (nth structure (dec (count structure)))))
-  (transform* [this structure next-fn]
-    (let [i (dec (count structure))]
-      (assoc! structure i (next-fn (nth structure i))))))
 
 #+clj
 (defn transient-all-select

--- a/src/clj/com/rpl/specter/impl.cljx
+++ b/src/clj/com/rpl/specter/impl.cljx
@@ -778,26 +778,6 @@
     (let [res (next-fn [])]
       (reduce conj! structure res))))
 
-#+clj
-(defn transient-all-select
-  [structure next-fn]
-  (into [] (r/mapcat #(next-fn (nth structure %))
-                     (range (count structure)))))
-
-#+cljs
-(defn transient-all-select
-  [structure next-fn]
-  (into []
-        (r/mapcat #(next-fn (nth structure %)))
-        (range (count structure))))
-
-(defn transient-all-transform!
-  [structure next-fn]
-  (reduce (fn [structure i]
-            (assoc! structure i (next-fn (nth structure i))))
-          structure
-          (range (count structure))))
-
 (defn extract-basic-filter-fn [path]
   (cond (fn? path)
         path

--- a/src/clj/com/rpl/specter/impl.cljx
+++ b/src/clj/com/rpl/specter/impl.cljx
@@ -797,15 +797,6 @@
           structure
           (range (count structure))))
 
-(deftype TransientAllNavigator [])
-
-(extend-protocol p/Navigator
-  TransientAllNavigator
-  (select* [this structure next-fn]
-    (transient-all-select structure next-fn))
-  (transform* [this structure next-fn]
-    (transient-all-transform! structure next-fn)))
-
 (defn extract-basic-filter-fn [path]
   (cond (fn? path)
         path

--- a/src/clj/com/rpl/specter/transient.cljx
+++ b/src/clj/com/rpl/specter/transient.cljx
@@ -9,7 +9,7 @@
          [defnav
           defpathedfn]])
   (:require [com.rpl.specter.impl :as i]
-            [com.rpl.specter :refer [subselect]]))
+            [com.rpl.specter :refer [subselect selected?]]))
 
 (defnav
   ^{:doc "Navigates to the specified key of a transient collection,
@@ -32,18 +32,6 @@
 (def LAST!
   "Navigates to the last element of a transient vector."
   (i/comp-paths* [(i/->TransientLastNavigator)]))
-
-(def ALL!
-  ;; TODO: only works on transient vectors, not sets / maps; need a
-  ;; different name?
-  "Navigates to each element of a transient vector."
-  (i/comp-paths* [(i/->TransientAllNavigator)]))
-
-(defpathedfn filterer!
-  "Navigates to a view of the current transient vector that only
-  contains elements that match the given path."
-  [& path]
-  (subselect ALL! (selected? path)))
 
 (defn- select-keys-from-transient-map
   "Selects keys from transient map, because built-in select-keys uses

--- a/src/clj/com/rpl/specter/transient.cljx
+++ b/src/clj/com/rpl/specter/transient.cljx
@@ -86,6 +86,6 @@
         (reduce (fn [m k]
                   (dissoc! m k))
                 % m-keys)
-        (reduce (fn [m [k v]]
-                  (assoc! m k v))
-                % res)))))
+        (reduce-kv (fn [m k v]
+                     (assoc! m k v))
+                   % res)))))

--- a/src/clj/com/rpl/specter/transient.cljx
+++ b/src/clj/com/rpl/specter/transient.cljx
@@ -25,13 +25,30 @@
   "Navigates to an empty (persistent) vector at the end of a transient vector."
   (i/comp-paths* [(i/->TransientEndNavigator)]))
 
+(defn- t-get-first
+  [tv]
+  (nth tv 0))
+
+(defn- t-get-last
+  [tv]
+  (nth tv (dec (i/transient-vec-count tv))))
+
+(defn- t-update-first
+  [tv next-fn]
+  (assoc! tv 0 (next-fn (nth tv 0))))
+
+(defn- t-update-last
+  [tv next-fn]
+  (let [i (dec (i/transient-vec-count tv))]
+    (assoc! tv i (next-fn (nth tv i)))))
+
 (def FIRST!
   "Navigates to the first element of a transient vector."
-  (keypath! 0))
+  (i/->PosNavigator t-get-first t-update-first))
 
 (def LAST!
   "Navigates to the last element of a transient vector."
-  (i/comp-paths* [(i/->TransientLastNavigator)]))
+  (i/->PosNavigator t-get-last t-update-last))
 
 (defn- select-keys-from-transient-map
   "Selects keys from transient map, because built-in select-keys uses
@@ -54,7 +71,7 @@
   submap!
   [m-keys]
   (select* [this structure next-fn]
-    (select-keys-from-transient-map structure m-keys))
+    (next-fn (select-keys-from-transient-map structure m-keys)))
   (transform* [this structure next-fn]
     (let [selected (select-keys-from-transient-map structure m-keys)
           res (next-fn selected)]

--- a/src/clj/com/rpl/specter/transient.cljx
+++ b/src/clj/com/rpl/specter/transient.cljx
@@ -50,6 +50,7 @@
   "Navigates to the last element of a transient vector."
   (i/->PosNavigator t-get-last t-update-last))
 
+#+clj
 (defn- select-keys-from-transient-map
   "Selects keys from transient map, because built-in select-keys uses
   `find` which is unsupported."
@@ -65,6 +66,12 @@
                  (assoc result k item)
                  result)
                (rest m-keys))))))
+
+#+cljs
+(defn- select-keys-from-transient-map
+  "Uses select-keys on a transient map."
+  [m m-keys]
+  (select-keys m m-keys))
 
 (defnav
   ^{:doc "Navigates to the specified persistent submap of a transient map."}

--- a/src/clj/com/rpl/specter/transient.cljx
+++ b/src/clj/com/rpl/specter/transient.cljx
@@ -1,0 +1,79 @@
+(ns com.rpl.specter.transient
+  #+cljs
+  (:require-macros [com.rpl.specter.macros
+                    :refer
+                    [defnav
+                     defpathedfn]])
+  (:use #+clj
+        [com.rpl.specter.macros :only
+         [defnav
+          defpathedfn]])
+  (:require [com.rpl.specter.impl :as i]
+            [com.rpl.specter :refer [subselect]]))
+
+(defnav
+  ^{:doc "Navigates to the specified key of a transient collection,
+          navigating to nil if it doesn't exist."}
+  keypath!
+  [key]
+  (select* [this structure next-fn]
+    (next-fn (get structure key)))
+  (transform* [this structure next-fn]
+    (assoc! structure key (next-fn (get structure key)))))
+
+(def END!
+  "Navigates to an empty (persistent) vector at the end of a transient vector."
+  (i/comp-paths* [(i/->TransientEndNavigator)]))
+
+(def FIRST!
+  "Navigates to the first element of a transient vector."
+  (keypath! 0))
+
+(def LAST!
+  "Navigates to the last element of a transient vector."
+  (i/comp-paths* [(i/->TransientLastNavigator)]))
+
+(def ALL!
+  ;; TODO: only works on transient vectors, not sets / maps; need a
+  ;; different name?
+  "Navigates to each element of a transient vector."
+  (i/comp-paths* [(i/->TransientAllNavigator)]))
+
+(defpathedfn filterer!
+  "Navigates to a view of the current transient vector that only
+  contains elements that match the given path."
+  [& path]
+  (subselect ALL! (selected? path)))
+
+(defn- select-keys-from-transient-map
+  "Selects keys from transient map, because built-in select-keys uses
+  `find` which is unsupported."
+  [m m-keys]
+  (loop [result {}
+         m-keys m-keys]
+    (if-not (seq m-keys)
+      result
+      (let [k (first m-keys)
+            ;; support Clojure 1.6 where contains? is broken on transients
+            item (get m k ::not-found)]
+        (recur (if-not (identical? item ::not-found)
+                 (assoc result k item)
+                 result)
+               (rest m-keys))))))
+
+(defnav
+  ^{:doc "Navigates to the specified persistent submap of a transient map."}
+  submap!
+  [m-keys]
+  (select* [this structure next-fn]
+    (select-keys-from-transient-map structure m-keys))
+  (transform* [this structure next-fn]
+    (let [selected (select-keys-from-transient-map structure m-keys)
+          res (next-fn selected)]
+      (as-> structure %
+        (reduce (fn [m k]
+                  (dissoc! m k))
+                % m-keys)
+        (reduce (fn [m [k v]]
+                  (assoc! m k v))
+                % res)))))

--- a/test/com/rpl/specter/core_test.cljx
+++ b/test/com/rpl/specter/core_test.cljx
@@ -1054,7 +1054,7 @@
 
 (defspec transient-map-test
   (for-all+
-    [m (gen/not-empty (gen/map gen/keyword gen/int))
+    [m (limit-size 5 (gen/not-empty (gen/map gen/keyword gen/int)))
      new-key gen/keyword]
     (let [existing-key (first (keys m))]
       (every? identity

--- a/test/com/rpl/specter/core_test.cljx
+++ b/test/com/rpl/specter/core_test.cljx
@@ -25,6 +25,7 @@
             #+cljs [cljs.test.check.generators :as gen]
             #+cljs [cljs.test.check.properties :as prop :include-macros true]
             [com.rpl.specter :as s]
+            [com.rpl.specter.transient :as t]
             [clojure.set :as set]))
 
 ;;TODO:
@@ -1036,3 +1037,34 @@
     (is (= 2 (key e)))
     (is (= 4 (val e)))
     ))
+
+(defspec transient-vector-test
+  (for-all+
+    [v (gen/vector (limit-size 5 gen/int))]
+    (every? identity
+            (for [[path transient-path f]
+                  [[s/FIRST t/FIRST! (fnil inc 0)]  ;; fnil in case vector is empty
+                   [s/LAST t/LAST! (fnil inc 0)]
+                   [(s/keypath 0) (t/keypath! 0) (fnil inc 0)]
+                   [s/END t/END! #(conj % 1 2 3)]]]
+              (and (= (s/transform* path f v)
+                      (persistent! (s/transform* transient-path f (transient v))))
+                   (= (s/select* path v)
+                      (s/select* transient-path (transient v))))))))
+
+(defspec transient-map-test
+  (for-all+
+    [m (gen/not-empty (gen/map gen/keyword gen/int))
+     new-key gen/keyword]
+    (let [existing-key (first (keys m))]
+      (every? identity
+              (for [[path transient-path f]
+                    [[(s/keypath existing-key) (t/keypath! existing-key) inc]
+                     [(s/keypath new-key) (t/keypath! new-key) (constantly 3)]
+                     [(s/submap [existing-key new-key])
+                      (t/submap! [existing-key new-key])
+                      (constantly {new-key 1234})]]]
+                (and (= (s/transform* path f m)
+                        (persistent! (s/transform* transient-path f (transient m))))
+                     (= (s/select* path m)
+                        (s/select* transient-path (transient m)))))))))


### PR DESCRIPTION
A suite of navigators that work on transient collections is available in the `com.rpl.specter.transient` namespace.

For transient vectors: `END!`, `FIRST!`, `LAST!`, `keypath!`
For transient maps: `keypath!`, `submap!`
For transient sets: none supported