### PR TITLE
Removed type hint that was breaking AOT compile

### DIFF
--- a/src/clj/com/rpl/specter.cljc
+++ b/src/clj/com/rpl/specter.cljc
@@ -260,7 +260,7 @@
            (i/intern* *ns* cache-sym (i/mutable-cell)))
          `(let [info# ~get-cache-code
 
-                ^com.rpl.specter.impl.CachedPathInfo info#
+                info#
                 (if (nil? info#)
                   (let [~info-sym (i/magic-precompilation
                                    ~prepared-path


### PR DESCRIPTION
Fixes issue #160 . The expression actually evaluates to `com.rpl.specter.impl.CachedPathInfo`, but the "cast" fails somehow.