### PR TITLE
kill jvm reflection

### DIFF
--- a/src/clj/com/rpl/specter/impl.cljc
+++ b/src/clj/com/rpl/specter/impl.cljc
@@ -28,7 +28,7 @@
     (pr-str o)
     (str o)))
 
-(defn smart-str [& elems]
+(defn ^String smart-str [& elems]
   (apply str (map smart-str* elems)))
 
 (defn fast-constantly [v]

--- a/src/clj/com/rpl/specter/navs.cljc
+++ b/src/clj/com/rpl/specter/navs.cljc
@@ -130,9 +130,9 @@
                   (recur (+ i 2) (+ j 2)))))))
          (let [none-count (i/get-cell none-cell)
                array (if (not= 0 none-count)
-                        (java.util.Arrays/copyOf array (* 2 (- len none-count)))
-                        array
-                        )]
+                       (java.util.Arrays/copyOf array (int (* 2 (- len none-count))))
+                       array
+                       )]
           (clojure.lang.PersistentArrayMap/createAsIfByAssoc array)))))
 
 
@@ -246,7 +246,7 @@
                   (recur (+ i 2) (+ j 2)))))))
          (let [none-count (i/get-cell none-cell)
                array (if (not= 0 none-count)
-                        (java.util.Arrays/copyOf array (* 2 (- len none-count)))
+                        (java.util.Arrays/copyOf array (int (* 2 (- len none-count))))
                         array
                         )]
           (clojure.lang.PersistentArrayMap. array)))))


### PR DESCRIPTION
```
Reflection warning, com/rpl/specter/impl.cljc:148:15 - call to java.lang.IllegalArgumentException ctor can't be resolved.
Reflection warning, com/rpl/specter/impl.cljc:330:25 - call to java.lang.IllegalArgumentException ctor can't be resolved.
Reflection warning, com/rpl/specter/impl.cljc:345:25 - call to java.lang.IllegalArgumentException ctor can't be resolved.
Reflection warning, com/rpl/specter/impl.cljc:349:9 - call to java.lang.IllegalArgumentException ctor can't be resolved.
Reflection warning, com/rpl/specter/impl.cljc:665:14 - call to java.lang.IllegalArgumentException ctor can't be resolved.
Reflection warning, com/rpl/specter/impl.cljc:890:3 - call to java.lang.IllegalArgumentException ctor can't be resolved.
Reflection warning, com/rpl/specter/macros.clj:9:6 - call to java.lang.IllegalArgumentException ctor can't be resolved.
Reflection warning, com/rpl/specter.cljc:601:7 - call to java.lang.IllegalArgumentException ctor can't be resolved.
[...]
```

Minor stuff, but it's a bit noisy when reflection is "on" on the parent project.
I didn't test the cljs side of things.