### PR TITLE
Add cljs tests to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: clojure
+lein: 2.7.1
+cache:
+  directories:
+  - $HOME/.m2
 script:
   - lein test
+  - lein doo phantom test-build once

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,8 @@
   :test-paths ["test", "target/test-classes"]
   :auto-clean false
   :dependencies [[riddley "0.1.12"]]
-  :plugins [[lein-codox "0.9.5"]]
+  :plugins [[lein-codox "0.9.5"]
+            [lein-doo "0.1.7"]]
   :codox {:source-paths ["target/classes" "src/clj"]
           :namespaces [com.rpl.specter
                        com.rpl.specter.zipper
@@ -19,6 +20,12 @@
             {#"target/classes" "https://github.com/nathanmarz/specter/tree/{version}/src/clj/{classpath}x#L{line}"
              #".*"             "https://github.com/nathanmarz/specter/tree/{version}/src/clj/{classpath}#L{line}"}}
 
+
+  :cljsbuild {:builds [{:id "test-build"
+                        :source-paths ["src/clj" "target/classes" "test"]
+                        :compiler {:output-to "out/testable.js"
+                                   :main 'com.rpl.specter.cljs-test-runner
+                                   :optimizations :simple}}]}
 
   :profiles {:dev {:dependencies
                    [[org.clojure/test.check "0.9.0"]

--- a/test/com/rpl/specter/cljs_test_runner.cljs
+++ b/test/com/rpl/specter/cljs_test_runner.cljs
@@ -1,8 +1,7 @@
 (ns com.rpl.specter.cljs-test-runner
-  (:require [cljs.test :as test :refer-macros [run-tests]]
+  (:require [doo.runner :refer-macros [doo-tests]]
             [com.rpl.specter.core-test]
             [com.rpl.specter.zipper-test]))
 
-
-(run-tests 'com.rpl.specter.core-test)
-(run-tests 'com.rpl.specter.zipper-test)
+(doo-tests 'com.rpl.specter.core-test
+           'com.rpl.specter.zipper-test)


### PR DESCRIPTION
* Add lein-doo plugin to run cljs tests. This is the new recommended
  approach.
* Update project.clj to add cljsbuild config
* Update .travis.yml file to run cljs tests as well.

To run do:
$ lein do javac, doo phantom test-build once

Note that you'll need phantomjs installed for above to work.

Fixed #77 