### PR TITLE
Switch to node-js build engine for cljs tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ lein: 2.7.1
 cache:
   directories:
   - $HOME/.m2
-#before_script:
-#  - mkdir travis-phantomjs
-#  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
-#  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
-#  - export PATH=$PWD/travis-phantomjs:$PATH
 script:
   - lein test
-#  - lein doo phantom test-build once
+  - lein doo node test-build once

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,8 @@
                         :source-paths ["src/clj" "target/classes" "test"]
                         :compiler {:output-to "out/testable.js"
                                    :main 'com.rpl.specter.cljs-test-runner
-                                   :optimizations :simple}}]}
+                                   :target :nodejs
+                                   :optimizations :none}}]}
 
   :profiles {:dev {:dependencies
                    [[org.clojure/test.check "0.9.0"]


### PR DESCRIPTION
I have switched to node-js instead of phantomjs. Looks like there is some issue on travis with old phantomjs. I ran this commit twice on travis. Both time it ran fine. Please give this a try. This should fix #190 & #77