### PR TITLE
Improve readability of selection in regex-nav.

### DIFF
--- a/src/clj/com/rpl/specter.cljc
+++ b/src/clj/com/rpl/specter.cljc
@@ -1070,8 +1070,7 @@
 
 (defnav regex-nav [re]
   (select* [this structure next-fn]
-           (doseqres NONE [s (re-seq re structure)]
-                     (next-fn s)))
+           (n/all-select (re-seq re structure) next-fn))
   (transform* [this structure next-fn]
               (clojure.string/replace structure re next-fn)))
 


### PR DESCRIPTION
I was poking around the code and saw all-select in the navs namespace - reusing it in the implementation of regex-nav makes the code shorter and clarifies what's happening, namely that we're automatically selecting on ALL the matches of re-seq. Feel free to close if you don't like it or don't want to reuse that function.