### PR TITLE
Fix ns form to comply with cljs.core.specs.alpha

### DIFF
--- a/src/clj/com/rpl/specter/navs.cljc
+++ b/src/clj/com/rpl/specter/navs.cljc
@@ -5,8 +5,8 @@
               [defnav defrichnav]]
             [com.rpl.specter.util-macros :refer
               [doseqres]]))
-  (:use #?(:clj [com.rpl.specter.macros :only [defnav defrichnav]])
-        #?(:clj [com.rpl.specter.util-macros :only [doseqres]]))
+  #?(:clj (:use [com.rpl.specter.macros :only [defnav defrichnav]]
+                [com.rpl.specter.util-macros :only [doseqres]]))
   (:require [com.rpl.specter.impl :as i]
             #?(:clj [clojure.core.reducers :as r])))
 


### PR DESCRIPTION
When requiring the cljs.core.specs.alpha namespace with ClojureScript
1.10, the ns form in com.rpl.specter.navs fails spec validation and
produces a compile error, because the nested :clj reader conditionals
result in an empty :use clause.

Moving the reader conditional up to enclose :use fixes this.

Relevant spec:
https://github.com/clojure/clojurescript/blob/b11cbeefa5c148b256bcc0942d714c23ab4c6c81/src/main/cljs/cljs/core/specs/alpha.cljc#L170

Additional info:
https://clojurescript.org/news/2018-03-26-release#_core_specs_alpha

Compiler error message:
```
----  Could not Analyze  jar:file:/Users/gnl/.m2/repository/com/rpl/specter/1.1.0/specter-1.1.0.jar!/com/rpl/specter/navs.cljc   line:1  column:1  ----

  Call to cljs.core/ns-special-form did not conform to spec:
In: [2 0] val: :use fails spec: :cljs.core.specs.alpha/ns-refer-clojure at: [:args :clauses :refer-clojure :clause] predicate: #{:refer-clojure}
In: [2 0] val: :use fails spec: :cljs.core.specs.alpha/ns-require at: [:args :clauses :require :clause] predicate: #{:require}
In: [2 0] val: :use fails spec: :cljs.core.specs.alpha/ns-require-macros at: [:args :clauses :require-macros :clause] predicate: #{:require-macros}
In: [2 0] val: :use fails spec: :cljs.core.specs.alpha/ns-import at: [:args :clauses :import :clause] predicate: #{:import}
In: [2] val: () fails spec: :cljs.core.specs.alpha/ns-use at: [:args :clauses :use :libs] predicate: (alt :libspec :cljs.core.specs.alpha/use-libspec :flag #{:verbose :reload :reload-all}),  Insufficient input
In: [2 0] val: :use fails spec: :cljs.core.specs.alpha/ns-use-macros at: [:args :clauses :use-macros :clause] predicate: #{:use-macros}


----  Analysis Error : Please see jar:file:/Users/gnl/.m2/repository/com/rpl/specter/1.1.0/specter-1.1.0.jar!/com/rpl/specter/navs.cljc  ----
```