### PR TITLE
use criterium for benchmarks

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,8 @@
                    [[org.clojure/test.check "0.9.0"]
                     [org.clojure/clojure "1.9.0"]
                     [org.clojure/clojurescript "1.10.439"]]}
-
+             :bench {:dependencies [[org.clojure/clojure "1.9.0"]
+                                    [criterium "0.4.4"]]}
              :test {:dependencies [[org.clojure/clojure "1.7.0"]]}}
 
   :aliases {"deploy" ["do" "clean," "deploy" "clojars"]})

--- a/scripts/run-benchmarks
+++ b/scripts/run-benchmarks
@@ -1,4 +1,8 @@
 #!/bin/bash
 
-`lein javac`
-java -server -XX:MaxPermSize=128m -XX:MaxInlineSize=100 -cp `lein classpath` clojure.main scripts/benchmarks.clj 
+lein javac
+lein version
+echo
+lein show-profiles bench
+echo
+java -server -XX:MaxInlineSize=100 -cp "$(lein with-profile bench classpath)" clojure.main scripts/benchmarks.clj


### PR DESCRIPTION
Hi @nathanmarz ,

when looking through [your benchmarks](https://gist.github.com/nathanmarz/b7c612b417647db80b9eaab618ff8d83) I noticed a comment asking why haven't you used [criterium](https://github.com/hugoduncan/criterium/). Microbenchmarks are really hard to get right and the JVM adds more pitfalls (is the running code native or not? Or did it become native in the middle of the benchmarking?).

For a more accurate comparison I updated the benchmark code to use criterium. I also [published the results](https://gist.github.com/xificurC/df079feb85bb118efd305764c8714cf5). The results are (I think) still satisfying.